### PR TITLE
Prevent bleed of problem count between lint runs, fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,47 @@
 const CLIEngine = require("eslint").CLIEngine
-var counts = 0
 
 function createLinter (cli) {
   const fmt = cli.getFormatter()
   return (file) => {
     const report = cli.executeOnFiles([file])
     const msg = fmt(report.results)
-    if (msg === "") return
-    console.error(msg)
-    counts += parseInt(report.errorCount + report.warningCount)
+
+    if (msg.length > 0) {
+      console.warn(msg)
+    }
+
+    return {
+      errorCount: parseInt(report.errorCount),
+      warningCount: parseInt(report.warningCount)
+    }
   }
 }
+
+function sumProperty(key) {
+  return (count, obj) => count += obj[key]
+}
+
+function LinterError(message) {
+  this.name = 'LinterError'
+  this.message = message || ''
+}
+
+LinterError.prototype = Object.create(Error.prototype)
 
 module.exports = function () {
   this.eslint = function (opts) {
     const lint = createLinter(new CLIEngine(opts))
+
     return this.unwrap((files) => {
-      files.forEach(file => lint(file))
-      if (counts > 0) throw counts + " problems."
+      const problems = files.map(file => lint(file))
+        .filter((problem) => problem.errorCount > 0 || problem.warningCount > 0)
+
+      const errorCount = problems.reduce(sumProperty('errorCount'), 0)
+      const warningCount = problems.reduce(sumProperty('warningCount'), 0)
+
+      if (errorCount > 0 || warningCount > 0) {
+        throw new LinterError(errorCount + ' errors and ' + warningCount + ' warnings in ' + problems.length + ' files.')
+      }
     })
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,10 @@ const state = {
   fail: {
     msg: "fail lint",
     spec: [join("test", "fixtures", "fail.js")]
+  },
+  nobleed: {
+    msg: "pass lint after failed one",
+    spec: [join("test", "fixtures", "pass.js")]
   }
 }
 const unwrap = function (f) { return f(this.spec) }
@@ -18,6 +22,7 @@ test("fly-eslint", function (t) {
   t.ok(fly.eslint !== undefined, "inject eslint in fly instance")
   run.call(fly, t, state.pass, true)
   run.call(fly, t, state.fail, false)
+  run.call(fly, t, state.nobleed, true)
   t.end()
 })
 
@@ -27,6 +32,10 @@ function run (t, state, pass) {
     this.eslint()
     t.ok(pass, state.msg)
   } catch (e) {
-    t.ok(!pass, state.msg)
+    if (e.name === 'LinterError') {
+      t.ok(!pass, state.msg)
+    } else {
+      throw e
+    }
   }
 }


### PR DESCRIPTION
This 
- does away with the bleeding `counts` variable
- adds a relevant test-case `no-bleed`
- changes the thrown error to give information about number of warnings, errors and affected files
