### PR TITLE
Move eslint to peerDependencies, allow broader semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "test-harmony": "node --harmony --harmony_arrow_functions ./node_modules/tape/bin/tape test/*.js"
   },
   "author": "Jorge Bucaran",
-  "dependencies": {
-    "eslint": "^0.24.0"
+  "peerDependencies": {
+    "eslint": ">= 0.24.0"
   },
   "devDependencies": {
+    "eslint": ">= 0.24.0",
     "tap-spec": "^4.0.2",
     "tape": "^4.0.0"
   },


### PR DESCRIPTION
This
- Moves the former `dependencies` to `peerDependencies`
- Adds eslint `>= v0.24.0` to `devDependencies` for development
- Allows all eslint versions `>= v0.24.0`, making matching with other eslint versions in depending projects easier
