### PR TITLE
Accept every eslint version >= 0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "author": "Jorge Bucaran",
   "dependencies": {
-    "eslint": "^0.24.0"
+    "eslint": ">=0.24.0"
   },
   "devDependencies": {
     "tap-spec": "^4.0.2",


### PR DESCRIPTION
This is a PR competing with #7. 

This sets the semver range for eslint to `>=0.24.0`, allowing users to install any eslint version matching this range and make this plugin use the said version. 

This does not move eslint to `peerDependencies`.
