### PR TITLE
Support ESLint v2.x

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,8 +9,11 @@
     "no-shadow": 0,
     "no-use-before-define": 0
   },
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true
-  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "arrowFunctions": true,
+      "blockBindings": true
+    }
+  }
 }


### PR DESCRIPTION
Hello @bucaran.

Now, `fly-eslint` fell test of ESLint (`npm test`).
`ecmaFeatures` property has moved to `parserOptions` property in ESLint v2.x.
http://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options

Thank you.
